### PR TITLE
Inconsistent module name: WishScanner vs MindScanner

### DIFF
--- a/book/chapter-5.html
+++ b/book/chapter-5.html
@@ -2291,7 +2291,7 @@
 	<p>&#8220;Yes, any module which is introduced into a class with <code><span class="ident">include</span></code> is a mixin to that class.  If you go back and look at the <code><span class="ident">scan_for_a_wish</span></code> method, you&#8217;ll see that it calls a <code><span class="constant">self</span><span class="punct">.</span><span class="ident">read</span></code> method.  I just have to make sure that whatever class I&#8217;m mixing <code><span class="constant">WishScanner</span></code> into has a <code><span class="ident">read</span></code> method.  Otherwise, an error will be thrown.&#8221;</p>
 
 
-	<p>&#8220;That seems really wierd that the mixin requires certain methods that it doesn&#8217;t already have. It seems like it should work by itself.&#8221;</p>
+	<p>&#8220;That seems really weird that the mixin requires certain methods that it doesn&#8217;t already have. It seems like it should work by itself.&#8221;</p>
 
 
 	<p>Dr. Cham looked up from the keyboard at the goat.  &#8220;Well, it&#8217;s sort of like your video collection. None of your video cassettes work unless they are put in a machine that uses video cassettes. The depend on each other.  A mixin has some basic requirements, but once a class meets those requirements, you can add all this extra functionality in.&#8221;</p>

--- a/book/chapter-5.html
+++ b/book/chapter-5.html
@@ -2279,16 +2279,16 @@
 
 <div class='example'><pre><code> <span class="ident">require</span> <span class="punct">'</span><span class="string">mindreader</span><span class="punct">'</span>
  <span class="keyword">class </span><span class="class">MindReader</span>
-   <span class="ident">include</span> <span class="constant">MindScanner</span>
+   <span class="ident">include</span> <span class="constant">WishScanner</span>
  <span class="keyword">end</span></code></pre></div>
 
-	<p>&#8220;Now, the <code><span class="constant">MindScanner</span></code> module is mixed in to the <code><span class="constant">MindReader</span></code>,&#8221; said Dr. Cham. &#8220;I can call the <code><span class="ident">scan_for_a_wish</span></code> method on any <code><span class="constant">MindReader</span></code> object.&#8221;</p>
+	<p>&#8220;Now, the <code><span class="constant">WishScanner</span></code> module is mixed in to the <code><span class="constant">MindReader</span></code>,&#8221; said Dr. Cham. &#8220;I can call the <code><span class="ident">scan_for_a_wish</span></code> method on any <code><span class="constant">MindReader</span></code> object.&#8221;</p>
 
 
-	<p>&#8220;So, it&#8217;s a mixin,&#8221; said the goat.  &#8220;The <code><span class="constant">MindScanner</span></code> mixin.&#8221;</p>
+	<p>&#8220;So, it&#8217;s a mixin,&#8221; said the goat.  &#8220;The <code><span class="constant">WishScanner</span></code> mixin.&#8221;</p>
 
 
-	<p>&#8220;Yes, any module which is introduced into a class with <code><span class="ident">include</span></code> is a mixin to that class.  If you go back and look at the <code><span class="ident">scan_for_a_wish</span></code> method, you&#8217;ll see that it calls a <code><span class="constant">self</span><span class="punct">.</span><span class="ident">read</span></code> method.  I just have to make sure that whatever class I&#8217;m mixing <code><span class="constant">MindScanner</span></code> into has a <code><span class="ident">read</span></code> method.  Otherwise, an error will be thrown.&#8221;</p>
+	<p>&#8220;Yes, any module which is introduced into a class with <code><span class="ident">include</span></code> is a mixin to that class.  If you go back and look at the <code><span class="ident">scan_for_a_wish</span></code> method, you&#8217;ll see that it calls a <code><span class="constant">self</span><span class="punct">.</span><span class="ident">read</span></code> method.  I just have to make sure that whatever class I&#8217;m mixing <code><span class="constant">WishScanner</span></code> into has a <code><span class="ident">read</span></code> method.  Otherwise, an error will be thrown.&#8221;</p>
 
 
 	<p>&#8220;That seems really wierd that the mixin requires certain methods that it doesn&#8217;t already have. It seems like it should work by itself.&#8221;</p>

--- a/book/chapter-6.html
+++ b/book/chapter-6.html
@@ -2131,7 +2131,7 @@ Answer: Yes.</p>
    <span class="keyword">end</span>
  <span class="keyword">end</span></code></pre></div>
 
-	<p>Do you see the unreadable deer language in the example code?  The <code><span class="punct">/</span><span class="regex">^<span class="escape">\w</span>{8,15)$</span><span class="punct">/</span></code> is a regular expression.  If I may translate, the regexp is saying, <em>Please only allow letters, numbers or underscores.  No less than eight and no more than fifteen.</em></p>
+	<p>Do you see the unreadable deer language in the example code?  The <code><span class="punct">/</span><span class="regex">^<span class="escape">\w</span>{8,15}$</span><span class="punct">/</span></code> is a regular expression.  If I may translate, the regexp is saying, <em>Please only allow letters, numbers or underscores.  No less than eight and no more than fifteen.</em></p>
 
 
 	<p>Regular expressions are a mini-language built into Ruby and many other programming languages. I really shouldn&#8217;t say <em>mini</em>, though, since regexps can be twisted and complicated and much more difficult than any Ruby program.</p>


### PR DESCRIPTION
In [Chapter 5, Section 7,](http://mislav.uniqpath.com/poignant-guide/book/chapter-5.html#section7) a module's name is abruptly changed from WishScanner to MindScanner. I think it should be WishScanner throughout.

There was also one small typo in the vicinity.
