### PR TITLE
Change ri option from -c to -l

### DIFF
--- a/book/expansion-pak-1.md
+++ b/book/expansion-pak-1.md
@@ -273,7 +273,7 @@ Though instance methods use a pound key rather than a dot. (Since the dot can
 mean class **or** instance methods.) I mean: `ri Class#method`.
 
 The full spread of classes, a full list from the Very Top down to the Earth’s
-core, can be achieved with `ri -c`.
+core, can be achieved with `ri -l`.
 
 And beyond text, you can make <span class="caps">HTML</span>:
 


### PR DESCRIPTION
`-c` was removed from ruby source code in Sept. 2008. The `-l` option serves
the same purpose (listing all class names).

To check the `-l` option, make sure to use `ri --help` instead of the man page for `ri` as the man page does not show this option.
