### PR TITLE
remove whytheluckystiff.net link

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ description: >
 
     <p class=vcard>
     Tenderly written and illustrated by
-    <a rel=author class=fn href="http://whytheluckystiff.net">Why the Lucky Stiff</a>.
+    _Why the Lucky Stiff
     <br>
     <a href="https://github.com/mislav/poignant-guide">Source on GitHub</a>
     </p>


### PR DESCRIPTION
Hey Mislav,
The domain whytheluckystiff.net is no longer owned by _Why. Some random guy has his blog up there now. See this hacker news thread: https://news.ycombinator.com/item?id=7357580

Have a good one!

Joe
