### PR TITLE
Only classes can have a superclass

### DIFF
--- a/_posts/1900-01-05-them-what.md
+++ b/_posts/1900-01-05-them-what.md
@@ -1588,7 +1588,7 @@ end
 {% endhighlight %}
 
 `ArrayMine` is now a custom `Array` class with its own `join` method. `Array` is
-the **superclass** of `ArrayMine`. Every object has a `superclass` method where
+the **superclass** of `ArrayMine`. Every class has a `superclass` method where
 you can verify this relationship.
 
     irb> ArrayMine.superclass


### PR DESCRIPTION
The original statement that "Every object has a superclass method" is incorrect. Only objects that happen to be classes have a superclass method.
