### PR TITLE
Correct misstatement. s/method/module/

### DIFF
--- a/_posts/1900-01-05-them-what.md
+++ b/_posts/1900-01-05-them-what.md
@@ -2774,7 +2774,7 @@ in people’s heads.”
 
 “Because a `Module` is simpler than a class. It’s basically just a storage
 facility for methods. It keeps a group of methods together. You can’t create new
-objects from a method.”
+objects from a module.”
 
 “But aren’t you going to want a `WishScanner` object, so you can actually use
 it?” said the goat, appalled.


### PR DESCRIPTION
From the context, it seems that _why meant to say module not method.
