### PR TITLE
Explicitly interpolate symbol into string

### DIFF
--- a/_posts/1900-01-06-downtown.md
+++ b/_posts/1900-01-06-downtown.md
@@ -1512,7 +1512,7 @@ You can, however, have a method which **answers to many names**.
 {% highlight ruby %}
 class NameCaller
   def method_missing( name, *args )
-    puts "You're calling `" + name + "' and you say:"
+    puts "You're calling `#{name}' and you say:"
     args.each { |say| puts "  " + say }
     puts "But no one is there yet."
   end


### PR DESCRIPTION
The name parameter contains a symbol. Concatenating that symbol with strings causes this error:
TypeError: no implicit conversion of Symbol into String.

String interpolation fixes this with an implicit call to #to_s.
