### PR TITLE
Fix jekyll instructions in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ Since then I have:
 
 ## Build system
 
-Run `script/jekyll` to [build the site with Jekyll][jk].
+Run `jekyll serve` to [build the site with Jekyll][jk].
 
 The individual chapters are in `_posts/` directory.
 


### PR DESCRIPTION
Looks like `script/jekyll` was removed. I opted to change the instructions vs. add the script, but happy to change that approach if you'd prefer it.